### PR TITLE
Only strip module extension if script does not have one

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,12 @@ export function stripExt(name) {
 
 export default function(meta) {
   const modulePath = fileURLToPath(meta.url);
+
   const scriptPath = process.argv[1];
-  return stripExt(modulePath) === stripExt(scriptPath);
+  const extension = path.extname(scriptPath);
+  if (extension) {
+    return modulePath === scriptPath;
+  }
+
+  return stripExt(modulePath) === scriptPath;
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   ],
   "scripts": {
     "pretest": "eslint .",
-    "test:with-extension": "node --no-warnings test.js",
-    "test:without-extension": "node --no-warnings test",
-    "test:without-node": "NODE_NO_WARNINGS=1 ./test.js",
-    "test": "npm-run-all test:*"
+    "test:with-extension": "node test.js",
+    "test:without-extension": "node test",
+    "test:without-node": "./test.js",
+    "test": "NODE_NO_WARNINGS=1 npm-run-all test:*"
   },
   "keywords": [
     "require.main",


### PR DESCRIPTION
As @devsnek [pointed out](https://github.com/nodejs/modules/issues/274#issuecomment-588530609), there are potential edge cases where this function falls short.  Among them, if you have lots of scripts with the same name and different extensions, the function gets confused.

For example, if you run `node main.foo`, and `main.foo` is a module that imports `./main.bar`, then `main.bar` could accidentally think it is the "main" module.  The change in this branch handles that case.

In a vanilla setup, trying to `import './main.bar'` results in `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".bar"`, so I don't think this is a big concern.

The other suggestion was that this function will not work in the REPL.  Alas, `import.meta` cannot be used in the REPL, so I don't think this is worth addressing.