### PR TITLE
Point TypeScript to the type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Test if an ES module is run directly (require.main replacement)",
   "main": "main.js",
   "type": "module",
+  "types": "main.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/tschaub/es-main.git"


### PR DESCRIPTION
This adds a `type` member to the `package.json` to point TypeScript to the bundled `main.d.ts`.