### PR TITLE
Handle cases where process.argv[1] is falsey

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,9 +23,13 @@ export function stripExt(name) {
  * @return {boolean} The module was run directly with node.
  */
 export default function esMain(meta) {
+  const scriptPath = process.argv[1];
+  if (!meta || !scriptPath) {
+    return false;
+  }
+
   const modulePath = fileURLToPath(meta.url);
 
-  const scriptPath = process.argv[1];
   const extension = path.extname(scriptPath);
   if (extension) {
     return modulePath === scriptPath;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:with-extension": "node test.js",
     "test:without-extension": "node test",
     "test:without-node": "./test.js",
+    "test:repl": "node --eval \"import('./main.js').then(mod => {if (mod.default({})) throw new Error('expected false')})\"",
     "test:types": "npx tsc --noEmit",
     "test": "npm-run-all test:*"
   },


### PR DESCRIPTION
This covers cases where someone might try to call the function in a REPL.

Fixes #21.