### PR TITLE
Support module resolution for directories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - '14'
+          - '16'
+          - '17'
+          - '18'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import process from 'process';
+import {createRequire} from 'module';
 import {fileURLToPath} from 'url';
 
 /**
@@ -17,16 +18,25 @@ export function stripExt(name) {
 }
 
 /**
+ * @type {NodeRequire}
+ */
+let require;
+
+/**
  * Check if a module was run directly with node as opposed to being
  * imported from another module.
  * @param {ImportMeta} meta The `import.meta` object.
  * @return {boolean} The module was run directly with node.
  */
 export default function esMain(meta) {
-  const scriptPath = process.argv[1];
-  if (!meta || !scriptPath) {
+  if (!meta || !process.argv[1]) {
     return false;
   }
+
+  if (!require) {
+    require = createRequire(meta.url);
+  }
+  const scriptPath = require.resolve(process.argv[1]);
 
   const modulePath = fileURLToPath(meta.url);
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:with-extension": "node test.js",
     "test:without-extension": "node test",
     "test:without-node": "./test.js",
+    "test:resolve-index": "node test-resolve-index",
+    "test:resolve-main": "node test-resolve-main",
     "test:repl": "node --eval \"import('./main.js').then(mod => {if (mod.default({})) throw new Error('expected false')})\"",
     "test:types": "npx tsc --noEmit",
     "test": "npm-run-all test:*"

--- a/test-resolve-index/index.js
+++ b/test-resolve-index/index.js
@@ -1,0 +1,4 @@
+import esMain from '../main.js';
+import {strictEqual} from 'assert';
+
+strictEqual(esMain(import.meta), true, 'run as main');

--- a/test-resolve-main/main.js
+++ b/test-resolve-main/main.js
@@ -1,0 +1,4 @@
+import esMain from '../main.js';
+import {strictEqual} from 'assert';
+
+strictEqual(esMain(import.meta), true, 'run as main');

--- a/test-resolve-main/package.json
+++ b/test-resolve-main/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "main.js"
+}


### PR DESCRIPTION
This makes it so `esMain` works in cases where `node dir` runs `node dir/index.js` or `node dir/mod.js` (assuming `dir` has a `package.json` with `main` set to `mod.js`).

Fixes #20.
Fixes #22.
