### PR TITLE
Use import.meta.main where available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           - '18'
           - '20'
           - '22'
+          - '24'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/main.js
+++ b/main.js
@@ -24,7 +24,13 @@ export function stripExt(name) {
  * @return {boolean} The module was run directly with node.
  */
 export default function esMain(meta) {
-  if (!meta || !process.argv[1]) {
+  if (!meta) {
+    return false;
+  }
+  if ('main' in meta) {
+    return !!meta.main;
+  }
+  if (!process.argv[1]) {
     return false;
   }
 


### PR DESCRIPTION
This updates the `esMain` function to use `import.meta.main` if it is defined (e.g. in [recent Node versions](https://nodejs.org/docs/latest/api/esm.html#importmetamain)).